### PR TITLE
Added version liferay portal 7.0.5-ga6

### DIFF
--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -7,6 +7,7 @@ function main {
 		files.liferay.com/private/ee/portal/6.1.30.5/liferay-portal-tomcat-6.1-ee-ga3-sp5-20160201142343123.zip
 		releases.liferay.com/portal/6.2.5-ga6/liferay-portal-tomcat-6.2-ce-ga6-20160112152609836.zip
 		files.liferay.com/private/ee/portal/6.2.10.21/liferay-portal-tomcat-6.2-ee-sp20-20170717160924965.zip
+		releases.liferay.com/portal/7.0.5-ga6/liferay-ce-portal-tomcat-7.0-ga6-20180320170724974.zip
 		releases.liferay.com/portal/7.0.6-ga7/liferay-ce-portal-tomcat-7.0-ga7-20180507111753223.zip
 		releases.liferay.com/portal/7.1.3-ga4/liferay-ce-portal-tomcat-7.1.3-ga4-20190508171117552.7z
 		releases.liferay.com/portal/7.2.0-ga1/liferay-ce-portal-tomcat-7.2.0-ga1-20190531153709761.7z


### PR DESCRIPTION
Hello,

After searching for an official docker image for Liferay I found this repository, but it's not present the Liferay's portal version that we are actually using in the project, and If we don't use the same version the application deployed in liferay it's not capable to start.

It will we possible add version "7.0.5-ga6" of Liferay portal in the actual list of release images?

Best regards.