### PR TITLE
Pr for #29

### DIFF
--- a/template/scripts/patch_liferay.sh
+++ b/template/scripts/patch_liferay.sh
@@ -36,7 +36,7 @@ function main {
 		echo "[LIFERAY] Patching Tool updated successfully."
 	fi
 
-	if [ -e ${LIFERAY_PATCHING_DIR}/liferay-*.zip ]
+	if [ `ls ${LIFERAY_PATCHING_DIR}/liferay-*.zip | wc -l` > 0 ]
 	then
 		if [ `ls ${LIFERAY_PATCHING_DIR}/liferay-*.zip | wc -l` == 1 ]
 		then


### PR DESCRIPTION
This solution uses `wc -l` to check if there are any files of the form `liferay-*.zip`.

Addresses issue #29 