### PR TITLE
Separate is a requirement for patching-tool apply, this saves spaces,…

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -211,6 +211,7 @@ function install_fix_pack {
 		cp releases/fix-packs/${FIX_PACK_FILE_NAME} ${TEMP_DIR}/liferay/patching-tool/patches
 
 		${TEMP_DIR}/liferay/patching-tool/patching-tool.sh install
+		${TEMP_DIR}/liferay/patching-tool/patching-tool.sh separate temp
 
 		rm -fr ${TEMP_DIR}/liferay/osgi/state/*
 		rm -f ${TEMP_DIR}/liferay/patching-tool/patches/*


### PR DESCRIPTION
… speeds up patching. The downside is that only the apply command will work which means that containers need to be recreated from the image if someone would like to install a different hotfix

Once this is merged, please kick off dxp-3-7210:
LIFERAY_DOCKER_IMAGE_FILTER=dxp-3-7210 ./build_all_images.sh 

There will be more hotfix related fixes in the upcoming days and I'm planning to add hotfix installation testing, this fix addresses only one type of changes. It would unblock the lrdcom team.