### PR TITLE
Upgrade minor version of JDK from 8u232 to 8u282

### DIFF
--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:8u232
+FROM azul/zulu-openjdk-alpine:8u282
 
 ARG LABEL_BUILD_DATE
 ARG LABEL_NAME


### PR DESCRIPTION
Java 8 v232 is old. The latest release of v282 has lot of security fixes.
Refer here - https://www.oracle.com/java/technologies/javase/8all-relnotes.html


Also fixes vulnerabilities in base image 

 ```
~  snyk container test azul/zulu-openjdk-alpine:8u282

Testing azul/zulu-openjdk-alpine:8u282...

Package manager:   apk
Project name:      docker-image|azul/zulu-openjdk-alpine
Docker image:      azul/zulu-openjdk-alpine:8u282
Platform:          linux/amd64
Licenses:          enabled

✓ Tested 34 dependencies for known issues, no vulnerable paths found.

 ~  snyk container test azul/zulu-openjdk-alpine:8u232

Testing azul/zulu-openjdk-alpine:8u232...

✗ Medium severity vulnerability found in openssl/libcrypto1.1
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-ALPINE310-OPENSSL-1051928
  Introduced through: openssl/libcrypto1.1@1.1.1d-r0, openssl/libssl1.1@1.1.1d-r0, apk-tools/apk-tools@2.10.4-r2, libtls-standalone/libtls-standalone@2.9.1-r0
  From: openssl/libcrypto1.1@1.1.1d-r0
  From: openssl/libssl1.1@1.1.1d-r0 > openssl/libcrypto1.1@1.1.1d-r0
  From: apk-tools/apk-tools@2.10.4-r2 > openssl/libcrypto1.1@1.1.1d-r0
  and 4 more...
  Fixed in: 1.1.1i-r0

✗ Medium severity vulnerability found in openssl/libcrypto1.1
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-ALPINE310-OPENSSL-587969
  Introduced through: openssl/libcrypto1.1@1.1.1d-r0, openssl/libssl1.1@1.1.1d-r0, apk-tools/apk-tools@2.10.4-r2, libtls-standalone/libtls-standalone@2.9.1-r0
  From: openssl/libcrypto1.1@1.1.1d-r0
  From: openssl/libssl1.1@1.1.1d-r0 > openssl/libcrypto1.1@1.1.1d-r0
  From: apk-tools/apk-tools@2.10.4-r2 > openssl/libcrypto1.1@1.1.1d-r0
  and 4 more...
  Fixed in: 1.1.1d-r2

✗ Medium severity vulnerability found in musl/musl-utils
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-ALPINE310-MUSL-1042764
  Introduced through: musl/musl-utils@1.1.22-r3, libc-dev/libc-utils@0.7.1-r0, meta-common-packages@meta
  From: musl/musl-utils@1.1.22-r3
  From: libc-dev/libc-utils@0.7.1-r0 > musl/musl-utils@1.1.22-r3
  From: meta-common-packages@meta > musl/musl@1.1.22-r3
  Fixed in: 1.1.22-r4

✗ Medium severity vulnerability found in libx11/libx11
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-ALPINE310-LIBX11-597139
  Introduced through: libx11/libx11@1.6.8-r1, libxext/libxext@1.3.4-r0, libxi/libxi@1.7.9-r2, libxrender/libxrender@0.9.10-r3, libxtst/libxtst@1.2.3-r3, zulu8-ca/zulu8-ca-jre@8.0.232-r3, zulu8-ca/zulu8-ca-jdk@8.0.232-r3
  From: libx11/libx11@1.6.8-r1
  From: libxext/libxext@1.3.4-r0 > libx11/libx11@1.6.8-r1
  From: libxi/libxi@1.7.9-r2 > libx11/libx11@1.6.8-r1
  and 4 more...
  Fixed in: 1.6.10-r0

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-ALPINE310-OPENSSL-587954
  Introduced through: openssl/libcrypto1.1@1.1.1d-r0, openssl/libssl1.1@1.1.1d-r0, apk-tools/apk-tools@2.10.4-r2, libtls-standalone/libtls-standalone@2.9.1-r0
  From: openssl/libcrypto1.1@1.1.1d-r0
  From: openssl/libssl1.1@1.1.1d-r0 > openssl/libcrypto1.1@1.1.1d-r0
  From: apk-tools/apk-tools@2.10.4-r2 > openssl/libcrypto1.1@1.1.1d-r0
  and 4 more...
  Fixed in: 1.1.1g-r0

✗ High severity vulnerability found in libx11/libx11
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-ALPINE310-LIBX11-608583
  Introduced through: libx11/libx11@1.6.8-r1, libxext/libxext@1.3.4-r0, libxi/libxi@1.7.9-r2, libxrender/libxrender@0.9.10-r3, libxtst/libxtst@1.2.3-r3, zulu8-ca/zulu8-ca-jre@8.0.232-r3, zulu8-ca/zulu8-ca-jdk@8.0.232-r3
  From: libx11/libx11@1.6.8-r1
  From: libxext/libxext@1.3.4-r0 > libx11/libx11@1.6.8-r1
  From: libxi/libxi@1.7.9-r2 > libx11/libx11@1.6.8-r1
  and 4 more...
  Fixed in: 1.6.12-r0


Package manager:   apk
Project name:      docker-image|azul/zulu-openjdk-alpine
Docker image:      azul/zulu-openjdk-alpine:8u232
Platform:          linux/amd64
Base image:        alpine:3.10.3
Licenses:          enabled

Tested 34 dependencies for known issues, found 6 issues.

Base Image     Vulnerabilities  Severity
alpine:3.10.3  4                1 high, 3 medium, 0 low

Recommendations for base image upgrade:

Minor upgrades
Base Image     Vulnerabilities  Severity
alpine:3.11.7  0                0 high, 0 medium, 0 low



 ✘  ~ 
```