### PR TITLE
Fix.graceful.shutdown

### DIFF
--- a/templates/base/scripts/liferay_entrypoint.sh
+++ b/templates/base/scripts/liferay_entrypoint.sh
@@ -3,7 +3,11 @@
 source /usr/local/bin/_liferay_common.sh
 
 function handle_kill_TERM {
-	kill -TERM ${START_LIFERAY_PID}
+	exec 5<>/dev/tcp/localhost/8005 && echo "SHUTDOWN" >&5
+
+	if [ $? -gt 0 ]; then
+		kill -TERM ${START_LIFERAY_PID}
+	fi
 }
 
 function main {

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=liferay:liferay liferay /opt/liferay
 
 RUN ln -fs /opt/liferay/* /home/liferay
 
-ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/liferay_entrypoint.sh"]
 
 ENV JPDA_ADDRESS=8000
 


### PR DESCRIPTION
Graceful shutdown is currently broken because of an inadvertent forking of the entrypoint script.

* Start a recent docker image `docker run -it --rm --name=liferay liferay/dxp:7.4.13.u1-nightly`
* exec into it `docker exec -it liferay /bin/bash`
* notice there are two processes for `liferay-entrypoint.sh`
```bash
$ ps -aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
liferay        1  0.4  0.0   2608   596 pts/0    Ss+  20:42   0:00 /bin/sh -c /usr/local/bin/liferay_entrypoint.sh
liferay        8  0.0  0.0   7104  3264 pts/0    S+   20:42   0:00 /bin/bash /usr/local/bin/liferay_entrypoint.sh
```

The problem is because ENTRYPOINT in docker defaults to executing a script using `/bin/sh -c` BUT the script file has a SHEBANG line to run `/bin/bash` which forks to bash to execute the script.

This means that all the signal handling that was added to support graceful shutdown and is meant to be running in pid 1 is actually running in a child process. This means external signals sent to the container won't actually reach those handlers.

Finally, the second commit adds the real graceful tomcat shutdown by sending the SHUTDOWN command to tomcat's server handler triggering an actual tomcat shutdown.