### PR TITLE
Fix SIGTERM not being handled

### DIFF
--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=liferay:liferay liferay /opt/liferay
 
 RUN ln -fs /opt/liferay/* /home/liferay
 
-ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/liferay_entrypoint.sh"]
 
 ENV JPDA_ADDRESS=8000
 


### PR DESCRIPTION
* Liferay is currently being started with the `liferay_entrypoint.sh`
  script not being PID 1. Instead, PID 1 is `/bin/sh` which then forks
  into the entrypoint script.
* This means that TERM signals sent to PID 1 are not propagated to the
  `liferay_entrypoint.sh` script.
* This means Liferay cannot be cleanly stopped, causing cleanup issues
  in Kubernetes, for example, leftover clustering data.
* Changed: ENTRYPOINT parameter changed to array syntax in order to
  prevent `/bin/sh` forking.