### PR TITLE
SRE-125 ARG should come before using it in FROM

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
-
 ARG VARIANT="jammy"
+
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
 	apt-get update && \


### PR DESCRIPTION
Hey @brianchandotcom,

The argument `variant` is being used in the FROM instruction and it should be defined first in order to work.
I've checked and this is needed to make it easy to configure the image variant Dev Container user/developer would like to use.

I've also checked whether we could move all ARG before our FROMs, but it would completely break them, see moby/moby#31352
> Basically, after the FROM instruction all the build arguments are reset and thus aren't available in the Dockerfile.

Kind regards,
Dávid