### PR TITLE
SRE-2871 Set permission so Liferay service's startup lock file can be created

### DIFF
--- a/orca/scripts/validate_environment.sh
+++ b/orca/scripts/validate_environment.sh
@@ -37,6 +37,7 @@ function create_dirs {
 	create_dir "/opt/liferay/db-data" 1001
 	create_dir "/opt/liferay/jenkins-home" 1000
 	create_dir "/opt/liferay/monitoring-proxy-db-data" 1001
+	create_dir "/opt/liferay/shared-volume" 1000
 	create_dir "/opt/liferay/shared-volume/document-library" 1000
 	create_dir "/opt/liferay/vault/data" 1000
 }


### PR DESCRIPTION
/opt/liferay/shared-volume's owner was root so the startup lock file cannot be created, startup was stuck.
Let's set the owner properly.