### PR TITLE
LPD-102472 Run the arguments given to the entrypoint instead of ignoring them

### DIFF
--- a/templates/node-runner/Dockerfile
+++ b/templates/node-runner/Dockerfile
@@ -15,6 +15,7 @@ ENTRYPOINT ["tini", "-v", "--", "/usr/local/bin/liferay_node_runner_entrypoint.s
 ENV LANG="C.UTF-8"
 ENV LIFERAY_NODE_RUNNER_START="npm start"
 ENV NODE_VERSION="v22"
+ENV PATH="/usr/local/node/${NODE_VERSION}/bin:${PATH}"
 
 LABEL org.label-schema.build-date="${LABEL_BUILD_DATE}"
 LABEL org.label-schema.name="${LABEL_NAME}"

--- a/templates/node-runner/resources/usr/local/bin/liferay_node_runner_entrypoint.sh
+++ b/templates/node-runner/resources/usr/local/bin/liferay_node_runner_entrypoint.sh
@@ -8,7 +8,12 @@ function main {
 		/usr/local/bin/liferay_node_runner_set_up.sh
 	fi
 
-	${LIFERAY_NODE_RUNNER_START}
+	if [ -n "${1}" ]
+	then
+		"${@}"
+	else
+		${LIFERAY_NODE_RUNNER_START}
+	fi
 
 	if [ -e /usr/local/bin/liferay_node_runner_tear_down.sh ]
 	then
@@ -16,4 +21,4 @@ function main {
 	fi
 }
 
-main
+main "${@}"

--- a/test_build_node_runner_image.sh
+++ b/test_build_node_runner_image.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+source ./_liferay_common.sh
+source ./_test_common.sh
+
+function main {
+	set_up
+
+	if [[ "${#}" -eq 1 ]]
+	then
+		"${1}"
+	else
+		test_build_node_runner_image_derived_image_installs_dependencies
+		test_build_node_runner_image_entrypoint_starts_default_command
+		test_build_node_runner_image_has_node_on_path
+		test_build_node_runner_image_switches_node_version
+	fi
+
+	tear_down
+}
+
+function set_up {
+	export _TEST_DERIVED_IMAGE="liferay/node-runner-derived:test"
+	export _TEST_NODE_RUNNER_IMAGE="liferay/node-runner:test"
+
+	docker build --tag "${_TEST_NODE_RUNNER_IMAGE}" templates/node-runner &> /dev/null
+
+	export _TEST_APP_DIR=$(mktemp --directory)
+
+	echo 'console.log("[LIFERAY_NODE_RUNNER_TEST] started");' > "${_TEST_APP_DIR}/app.js"
+
+	cat <<- EOF > "${_TEST_APP_DIR}/package.json"
+	{
+		"dependencies": {
+			"left-pad": "1.3.0"
+		},
+		"name": "liferay-node-runner-test",
+		"scripts": {
+			"start": "node app.js"
+		},
+		"version": "1.0.0"
+	}
+	EOF
+
+	cat <<- EOF > "${_TEST_APP_DIR}/Dockerfile"
+	FROM ${_TEST_NODE_RUNNER_IMAGE}
+
+	COPY --chown=liferay:liferay app.js package.json ./
+
+	RUN npm install --no-workspaces
+	EOF
+
+	docker build --tag "${_TEST_DERIVED_IMAGE}" "${_TEST_APP_DIR}" &> /dev/null
+}
+
+function tear_down {
+	docker rmi --force "${_TEST_DERIVED_IMAGE}" &> /dev/null
+	docker rmi --force "${_TEST_NODE_RUNNER_IMAGE}" &> /dev/null
+
+	rm --force --recursive "${_TEST_APP_DIR}"
+
+	unset _TEST_APP_DIR
+	unset _TEST_DERIVED_IMAGE
+	unset _TEST_NODE_RUNNER_IMAGE
+}
+
+function test_build_node_runner_image_derived_image_installs_dependencies {
+	assert_equals \
+		"$(docker run --entrypoint ls --rm "${_TEST_DERIVED_IMAGE}" node_modules)" \
+		"left-pad"
+}
+
+function test_build_node_runner_image_entrypoint_starts_default_command {
+	assert_equals \
+		"$(docker run --rm "${_TEST_DERIVED_IMAGE}" 2>&1 | grep --fixed-strings "[LIFERAY_NODE_RUNNER_TEST] started")" \
+		"[LIFERAY_NODE_RUNNER_TEST] started"
+}
+
+function test_build_node_runner_image_has_node_on_path {
+	assert_equals \
+		"$(docker run --entrypoint bash --rm "${_TEST_NODE_RUNNER_IMAGE}" -c 'command -v node &> /dev/null && command -v npm &> /dev/null && echo "true"')" \
+		"true"
+}
+
+function test_build_node_runner_image_switches_node_version {
+	assert_equals \
+		"$(_test_build_node_runner_image_node_version "v22")" \
+		"v22" \
+		"$(_test_build_node_runner_image_node_version "v24")" \
+		"v24"
+}
+
+function _test_build_node_runner_image_node_version {
+	docker run \
+		--env LIFERAY_NODE_RUNNER_START="node --version" \
+		--env NODE_VERSION="${1}" \
+		--rm \
+		"${_TEST_NODE_RUNNER_IMAGE}" 2>&1 | \
+		grep --extended-regexp "^v[0-9]+" | \
+		cut --delimiter='.' --fields=1
+}
+
+main "${@}"

--- a/test_build_node_runner_image.sh
+++ b/test_build_node_runner_image.sh
@@ -11,6 +11,7 @@ function main {
 		"${1}"
 	else
 		test_build_node_runner_image_derived_image_installs_dependencies
+		test_build_node_runner_image_entrypoint_passes_arguments
 		test_build_node_runner_image_entrypoint_starts_default_command
 		test_build_node_runner_image_has_node_on_path
 		test_build_node_runner_image_switches_node_version
@@ -68,6 +69,12 @@ function test_build_node_runner_image_derived_image_installs_dependencies {
 	assert_equals \
 		"$(docker run --entrypoint ls --rm "${_TEST_DERIVED_IMAGE}" node_modules)" \
 		"left-pad"
+}
+
+function test_build_node_runner_image_entrypoint_passes_arguments {
+	assert_equals \
+		"$(docker run --rm "${_TEST_NODE_RUNNER_IMAGE}" echo "[LIFERAY_NODE_RUNNER_TEST] argument" 2>&1 | grep --fixed-strings "[LIFERAY_NODE_RUNNER_TEST] argument")" \
+		"[LIFERAY_NODE_RUNNER_TEST] argument"
 }
 
 function test_build_node_runner_image_entrypoint_starts_default_command {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102472

**Stacked on #162.** This branch contains that commit as a dependency — the commit to review here is the second one, `LPD-102472 Run the arguments given to the entrypoint instead of ignoring them` (2 files, +15 −2). Happy to rebase once #162 lands.

## The behavior

`liferay_node_runner_entrypoint.sh` ends with `main` and never references `"${@}"`. Arguments handed to it are discarded, `${LIFERAY_NODE_RUNNER_START}` runs instead, and the exit status is 0:

```
RUN /usr/local/bin/liferay_node_runner_entrypoint.sh npm install

==> > node app.js
==> [APP] started
==> NO node_modules -- nothing was installed
```

The build goes green while doing something entirely different from what was asked. In PTR-9125 this was the workaround support recommended for the LPD-102431 regression, so a customer ended up shipping a dummy `package.json` to satisfy the `npm start` that actually ran.

## This is not a regression — please weigh that

Argument passthrough has never existed. Worth knowing before deciding:

- `064bc088` (2023-03-31) — file created, flat script, `$LIFERAY_NODE_RUNNER_START` only
- `9110f7a5` (2023-04-06) — a separate `$LIFERAY_NODE_RUNNER_INSTALL` step added, `ENV` in `e9564bce`
- `04505309` (2023-04-06) — that install step removed from the entrypoint the same day
- `1f260ed4` (2023-04-10) — orphaned `ENV` removed, *"I don't see this used anywhere?"*
- `e773aa52` (2023-04-27) — wrapped in `main`, called with no arguments

So the image once had a dedicated install phase and it was deliberately stripped. The surviving contract is narrow on purpose: one env var, one command, no argv. I split this out of LPD-102431 precisely so that regression fix doesn't have to carry this design question.

## What this does

Run `"${@}"` when arguments are present, fall back to `${LIFERAY_NODE_RUNNER_START}` otherwise. This is the standard Docker contract, where `CMD` arguments flow through to `ENTRYPOINT`; the image declares `CMD=[]`, so nothing relies on arguments being ignored. `install_node.sh` in the same directory already uses `main "${@}"`.

The `if` guard is required — an unconditional `"${@}"` would break the no-argument runtime path every existing CX depends on. Covered by the `entrypoint_starts_default_command` case.

It is also the only way to resolve `NODE_VERSION` at exec time, since the `ENV PATH` from #162 bakes in the default version.

## If you'd rather not change the contract

The ticket records a conservative alternative: keep the contract as is, and exit non-zero with a clear message when handed arguments that won't be run. That removes the silent-failure hazard — the part that actually caused harm — without changing three years of behavior. I'm happy to switch to it; say the word and I'll rework this.

Either way, the property worth having is that asking the entrypoint to do something it won't do must not exit 0.

## Test

Adds `entrypoint_passes_arguments` to `test_build_node_runner_image.sh`. Verified failing before this commit and passing after, with the rest of the file's cases still green (5/5 on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
